### PR TITLE
Temporary model name fix

### DIFF
--- a/rplidar.go
+++ b/rplidar.go
@@ -31,7 +31,7 @@ const (
 	defaultTimeout = uint(1000)
 )
 
-var Model = resource.NewModel("viam", "camera", "rplidar")
+var Model = resource.NewModel("rdk", "builtin", "rplidar")
 
 func init() {
 	registry.RegisterComponent(camera.Subtype, Model, registry.Component{Constructor: newRplidar})


### PR DESCRIPTION
We need to temporarily change the model name from "viam: camera:rplidar" to "rdk:builtin:rplidar" due to this fix: https://github.com/viamrobotics/app/pull/1010