### PR TITLE
Fix linux bug and update builds to not need library install

### DIFF
--- a/gen/third_party/rplidar_sdk-release-v1.12.0/sdk/sdk/src/arch/linux/net_socket.cpp
+++ b/gen/third_party/rplidar_sdk-release-v1.12.0/sdk/sdk/src/arch/linux/net_socket.cpp
@@ -167,7 +167,7 @@ u_result SocketAddress::getAddressAsString(char * buffer, size_t buffersize) con
 
         break;
     }
-    return ans<=0?RESULT_OPERATION_FAIL:RESULT_OK;
+    return *ans<=0?RESULT_OPERATION_FAIL:RESULT_OK;
 }
 
 


### PR DESCRIPTION
Small bug fix needed for newer linux, but mostly this is adjusting the makefile so that the static library doesn't have to be installed at the system level. As it's a static library, there's no point to that. The library code gets pulled directly into the built module/executable anyway.