### PR TITLE
RSDK-2209: Flip pointclouds returned by rplidar over the y axis

### DIFF
--- a/rplidar.go
+++ b/rplidar.go
@@ -227,9 +227,9 @@ func pointFrom(yaw, pitch, distance float64, reflectivity uint8) (r3.Vector, poi
 	pose2 := spatialmath.NewPoseFromPoint(r3.Vector{X: distance, Y: 0, Z: 0})
 	p := spatialmath.Compose(pose1, pose2).Point()
 
-	// Flip the point on the y axis.
-	p.X = -1 * p.X
-	p.Z = -1 * p.Z
+	// Rotate the point 180 degrees on the y axis. Since lidar data is always 2D, we don't worry
+	// about the Z value.
+	p.X = -p.X
 
 	pos := pointcloud.NewVector(p.X*1000, p.Y*1000, p.Z*1000)
 	d := pointcloud.NewBasicData()

--- a/rplidar.go
+++ b/rplidar.go
@@ -227,6 +227,10 @@ func pointFrom(yaw, pitch, distance float64, reflectivity uint8) (r3.Vector, poi
 	pose2 := spatialmath.NewPoseFromPoint(r3.Vector{X: distance, Y: 0, Z: 0})
 	p := spatialmath.Compose(pose1, pose2).Point()
 
+	// Flip the point on the y axis.
+	p.X = -1 * p.X
+	p.Z = -1 * p.Z
+
 	pos := pointcloud.NewVector(p.X*1000, p.Y*1000, p.Z*1000)
 	d := pointcloud.NewBasicData()
 	d.SetIntensity(uint16(reflectivity) * 255)


### PR DESCRIPTION
### Summary
[RSDK-2209](https://viam.atlassian.net/browse/RSDK-2209) describes an issue where the SLAM map appears flipped to users of SLAM. After investigating, I found that this is happening because the data returned by the rplidar module is not in the orientation that users would expect. Here are the coordinate systems of the A1 and A3 rplidars:

**Rplidar A1**
![rplidar_xy_plane](https://github.com/viamrobotics/rplidar/assets/9754276/5e1bd3c9-a354-48ca-8132-a9243905a1ac)

**Rplidar A3**
![rplidar_a3_xy_plane](https://github.com/viamrobotics/rplidar/assets/9754276/86082d61-140d-4cf1-8c30-89b2232c71a0)


Users should be able to mount their rplidar such that in some orientation _with the lidar facing up_, it's possible to have their robot move forward in space along the y axis and have everything to the right of the robot be considered x-positive. However this is not the case; both lidar models consider the z-positive axis to be beneath the lidar (towards the ground) and the z-negative axis to be above the lidar (towards the ceiling/sky). This means a user would have to mount the lidar upside-down on their robot to get the lidar data and SLAM map in the expected orientation.

### Manual Testing

In addition to the manual testing I did to discovered the coordinate system of each lidar, I also tested with the modified rplidar module to confirm that the new orientation was correct (for eg. objects to the right of the lidar appeared in the positive xy plane). I also tested that when the lidar is used as a sensor for SLAM (viam-cartographer), the map produced is no longer flipped, and that localization shows the lidar moving in the correct direction.

[RSDK-2209]: https://viam.atlassian.net/browse/RSDK-2209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ