### PR TITLE
RSDK-2995 - Fix Makefile & Readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,16 @@ TAG_VERSION?=$(shell git tag --points-at | sort -Vr | head -n1)
 CGO_LDFLAGS="-L 'gen/third_party/rplidar_sdk-release-${VERSION}/sdk/output/${OS}/Release/'"
 GO_BUILD_LDFLAGS = -ldflags "-X 'main.Version=${TAG_VERSION}' -X 'main.GitRevision=${GIT_REVISION}'"
 
+.PHONY: default
 default: build-module
 
+.PHONY: goformat
 goformat:
 	go install golang.org/x/tools/cmd/goimports
 	gofmt -s -w .
 	goimports -w -local=go.viam.com/utils `go list -f '{{.Dir}}' ./... | grep -Ev "proto"`
 
+.PHONY: lint
 lint: goformat
 	go install github.com/edaniels/golinters/cmd/combined
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint
@@ -20,29 +23,37 @@ lint: goformat
 	go list -f '{{.Dir}}' ./... | grep -v gen | xargs `go env GOPATH`/bin/go-errorlint -errorf
 	go list -f '{{.Dir}}' ./... | grep -v gen | xargs go run github.com/golangci/golangci-lint/cmd/golangci-lint run -v --config=./etc/.golangci.yaml
 
+.PHONY: test
 test:
 	go test -v -coverprofile=coverage.txt -covermode=atomic ./...
 
+.PHONY: sdk
 sdk:
 	cd gen/third_party/rplidar_sdk-release-${VERSION}/sdk && $(MAKE)
 
+.PHONY: clean-sdk
 clean-sdk:
 	cd gen/third_party/rplidar_sdk-release-${VERSION}/sdk && $(MAKE) clean_sdk
 
+.PHONY: swig
 swig: sdk
 	cd gen && swig -v -go -cgo -c++ -intgosize 64 gen.i
 
+.PHONY: build-module
 build-module: swig
 	mkdir -p bin && CGO_LDFLAGS=${CGO_LDFLAGS} go build $(GO_BUILD_LDFLAGS) -o bin/rplidar-module module/main.go
 
+.PHONY: clean
 clean: clean-sdk
 	rm -rf bin gen/gen_wrap.cxx gen/gen.go
 
+.PHONY: appimage
 appimage: build-module
 	cd etc/packaging/appimages && appimage-builder --recipe rplidar-module-`uname -m`.yml
 	mkdir -p etc/packaging/appimages/deploy/
 	mv etc/packaging/appimages/*.AppImage* etc/packaging/appimages/deploy/
 	chmod a+rx etc/packaging/appimages/deploy/*.AppImage
 
+.PHONY: clean-appimage
 clean-appimage:
 	rm -rf etc/packaging/appimages/AppDir && rm -rf etc/packaging/appimages/appimage-build && rm -rf etc/packaging/appimages/deploy

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,7 @@ TAG_VERSION?=$(shell git tag --points-at | sort -Vr | head -n1)
 CGO_LDFLAGS="-L 'gen/third_party/rplidar_sdk-release-${VERSION}/sdk/output/${OS}/Release/'"
 GO_BUILD_LDFLAGS = -ldflags "-X 'main.Version=${TAG_VERSION}' -X 'main.GitRevision=${GIT_REVISION}'"
 
-default: install-swig swig
-.PHONY: default
+default: build-module
 
 goformat:
 	go install golang.org/x/tools/cmd/goimports
@@ -29,13 +28,6 @@ sdk:
 
 clean-sdk:
 	cd gen/third_party/rplidar_sdk-release-${VERSION}/sdk && $(MAKE) clean_sdk
-
-install-swig:
-ifeq (, $(shell brew --version 2>/dev/null))
-	sudo apt install swig -y
-else
-	brew install swig	
-endif
 
 swig: sdk
 	cd gen && swig -v -go -cgo -c++ -intgosize 64 gen.i

--- a/README.md
+++ b/README.md
@@ -28,12 +28,21 @@ It has been tested on the following rplidars:
 
 ## Development
 
-Run `make install-swig`.
+### Dependencies
 
-### Run rplidar as a modular component
+Install the following list of dependencies:
+
+* [Golang](https://go.dev/doc/install)
+* `make`, `swig`, `jpeg`, `pkg-config`:
+    * MacOS: `brew install make swig pkg-config jpeg`
+    * Linux: `apt update && apt install -y make swig libjpeg-dev pkg-config`
+
+### Build & run rplidar as a modular component
 
 1. Build the module: `make build-module`
-2. Run the [RDK](https://github.com/viamrobotics/rdk) web server using one of the example config files [modules/sample_osx.json](./module/sample_osx.json) or [modules/sample_linux.json](./module/sample_linux.json), depending on your operating system.
+2. Run the [RDK](https://github.com/viamrobotics/rdk) web server using one of the example config files:
+    * MacOS: [modules/sample_osx.json](./module/sample_osx.json)
+    * Linux: [modules/sample_linux.json](./module/sample_linux.json)
 
 ### Linting
 


### PR DESCRIPTION
Ticket: https://viam.atlassian.net/browse/RSDK-2995

Changes made:
* Rather than adding more targets to the Makefile that install libraries, I removed those targets and instead added clear instructions in the README. This follows a common pattern in the Open Source community that gives the user more control and transparency over what is being installed on their system.

Tested on:
* MacOS x86_64
* Ubuntu Docker Image