### PR TITLE
hotfix/RSDK-3356-RPlidar-doesnt-boot-in-debug-mode

### DIFF
--- a/module/main.go
+++ b/module/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"go.viam.com/rplidar"
@@ -27,9 +26,6 @@ func main() {
 
 func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) error {
 	var versionFields []interface{}
-	if len(args) != 2 {
-		return fmt.Errorf("usage: %s [socket path] start module\nor: %s --version        print version & exit", args[0], args[0])
-	}
 	if Version != "" {
 		versionFields = append(versionFields, "version", Version)
 	}
@@ -42,7 +38,7 @@ func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) error
 		logger.Info(rplidar.Model.String() + " built from source; version unknown")
 	}
 
-	if strings.HasSuffix(args[1], "-version") {
+	if len(args) == 2 && strings.HasSuffix(args[1], "-version") {
 		return nil
 	}
 


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-3356)

Only exit the module process early if there is only one command line argument that is suffixed by `-version`. This makes it so that the debug logging https://viam.atlassian.net/browse/RSDK-2725 command line flag doesn't cause the module to terminate early in debug mode.

Manually tested using viam-server v0.2.49, stable, both with & without debug mode enabled.