### PR TITLE
RSDK-2841 Add Debug Log Detection

### DIFF
--- a/module/main.go
+++ b/module/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"strings"
 
 	"go.viam.com/rplidar"
@@ -21,7 +22,14 @@ var (
 )
 
 func main() {
-	utils.ContextualMain(mainWithArgs, golog.NewLogger("rplidarModule"))
+	utils.ContextualMain(mainWithArgs, NewLoggerFromArgs("rplidarModule"))
+}
+
+func NewLoggerFromArgs(moduleName string) golog.Logger {
+	if len(os.Args) >= 3 && os.Args[2] == "--log-level=debug" {
+		return golog.NewDebugLogger(moduleName)
+	}
+	return golog.NewDevelopmentLogger(moduleName)
 }
 
 func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) error {

--- a/module/main.go
+++ b/module/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"context"
-	"os"
 	"strings"
 
 	"go.viam.com/rplidar"
@@ -22,14 +21,7 @@ var (
 )
 
 func main() {
-	utils.ContextualMain(mainWithArgs, NewLoggerFromArgs("rplidarModule"))
-}
-
-func NewLoggerFromArgs(moduleName string) golog.Logger {
-	if len(os.Args) >= 3 && os.Args[2] == "--log-level=debug" {
-		return golog.NewDebugLogger(moduleName)
-	}
-	return golog.NewDevelopmentLogger(moduleName)
+	utils.ContextualMain(mainWithArgs, module.NewLoggerFromArgs("rplidarModule"))
 }
 
 func mainWithArgs(ctx context.Context, args []string, logger golog.Logger) error {


### PR DESCRIPTION
**Summary**
This PR adds debug logging by monitoring passed in args for `--log-level=debug`

**Testing**
Manual Run:
```
JHMac:rplidar (RSDK-2841_AddRuntimeDebugging) $ rplidar-module -version
2023-06-26T16:56:41.534-0400	INFO	rplidarModule	module/main.go:44 	viam:lidar:rplidar	{"git_rev": "64d4088017ed67dc7c31d5777ae14f6dff6fcfcc"}
```

Normal Config:
```
  "modules": [
    {
      "executable_path": "/usr/local/bin/rplidar-module",
      "name": "rplidar-module"
    }
  ]
```
```
JHMac:rdk (main) $ go run -tags dynamic web/cmd/server/main.go -config /etc/viam.json
2023-06-26T17:00:01.114-0400	INFO	robot_server	server/entrypoint.go:87	Viam RDK built from source; version unknown
2023-06-26T17:00:04.738-0400	INFO	robot_server.process.rplidar-module_/usr/local/bin/rplidar-module.StdOut	pexec/managed_process.go:224
\_ 2023-06-26T17:00:04.738-0400	INFO	rplidarModule	module/main.go:44	viam:lidar:rplidar	{"git_rev": "64d4088017ed67dc7c31d5777ae14f6dff6fcfcc"}
2023-06-26T17:00:04.739-0400	INFO	robot_server.process.rplidar-module_/usr/local/bin/rplidar-module.StdOut	pexec/managed_process.go:224
\_ 2023-06-26T17:00:04.739-0400	INFO	rplidarModule	module/module.go:193	server listening at /var/folders/r0/wtcwwm097g173xqkw6fkmqm00000gn/T/viam-module-3771907987/rplidar-module.sock
2023-06-26T17:00:04.743-0400	INFO	robot_server.process.rplidar-module_/usr/local/bin/rplidar-module.StdOut	pexec/managed_process.go:224
\_ 2023-06-26T17:00:04.743-0400	INFO	rplidarModule	rplidar/rplidar.go:83	attempting to connect to device at path /dev/tty.usbserial-0001
```

Normal config (debug):
```
  "modules": [
    {
      "executable_path": "/usr/local/bin/rplidar-module",
      "name": "rplidar-module",
      "log_level": "debug"
    }
  ]
```
```
JHMac:rdk (main) $ go run -tags dynamic web/cmd/server/main.go -config /etc/viam.json
2023-06-26T17:06:31.388-0400	INFO	robot_server	server/entrypoint.go:87	Viam RDK built from source; version unknown
2023-06-26T17:06:35.075-0400	INFO	robot_server.process.rplidar-module_/usr/local/bin/rplidar-module.StdOut	pexec/managed_process.go:224
\_ 2023-06-26T17:06:35.075-0400	INFO	rplidarModule	module/main.go:44	viam:lidar:rplidar	{"git_rev": "64d4088017ed67dc7c31d5777ae14f6dff6fcfcc"}
2023-06-26T17:06:35.076-0400	INFO	robot_server.process.rplidar-module_/usr/local/bin/rplidar-module.StdOut	pexec/managed_process.go:224
\_ 2023-06-26T17:06:35.076-0400	INFO	rplidarModule	module/module.go:193	server listening at /var/folders/r0/wtcwwm097g173xqkw6fkmqm00000gn/T/viam-module-2089766881/rplidar-module.sock
2023-06-26T17:06:35.079-0400	INFO	robot_server.process.rplidar-module_/usr/local/bin/rplidar-module.StdOut	pexec/managed_process.go:224
\_ 2023-06-26T17:06:35.079-0400	INFO	rplidarModule	rplidar/rplidar.go:83	attempting to connect to device at path /dev/tty.usbserial-0001
2023-06-26T17:06:41.126-0400	INFO	robot_server.process.rplidar-module_/usr/local/bin/rplidar-module.StdOut	pexec/managed_process.go:224
\_ 2023-06-26T17:06:41.126-0400	INFO	rplidarModule	rplidar/rplidar.go:90	found and connected to an A1 rplidar
2023-06-26T17:06:41.126-0400	INFO	robot_server.process.rplidar-module_/usr/local/bin/rplidar-module.StdOut	pexec/managed_process.go:224
\_ 2023-06-26T17:06:41.126-0400	DEBUG	rplidarModule	rplidar/rplidar.go:107	starting motor
2023-06-26T17:06:42.546-0400	INFO	robot_server	rpc/server.go:544	will run external signaling answerer	{"signaling_address": "app.viam.com:443", "for_hosts": ["jhlaptop-main.h63500gc3x.viam.cloud"]}
2023-06-26T17:06:42.549-0400	INFO	robot_server	web/web.go:890	serving	{"url": "https://jhlaptop-main.h63500gc3x.local.viam.cloud:8080", "alt_url": "https://0.0.0.0:8080"}
```
Bad Config:
```
  "modules": [
    {
      "executable_path": "/usr/local/bin/rplidar-module version",
      "name": "rplidar-module"
    }
  ]
```
```
2023-06-26T17:01:54.183-0400	ERROR	robot_server	config/config.go:100	module config error; starting robot without module	{"name": "rplidar-module", "error": "module modules.0 executable path error: stat /usr/local/bin/rplidar-module version: no such file or directory", "errorVerbose": "stat /usr/local/bin/rplidar-module version: no such file or directory\nmodule modules.0 executable path error\ngo.viam.com/rdk/config.(*Module).Validate\n\t/Users/jeremyhyde/Development/rdk/config/module.go:34\ngo.viam.com/rdk/config.(*Config).Ensure\n\t/Users/jeremyhyde/Development/rdk/config/config.go:96\ngo.viam.com/rdk/config.processConfig\n\t/Users/jeremyhyde/Development/rdk/config/reader.go:365\ngo.viam.com/rdk/config.processConfigFromCloud\n\t/Users/jeremyhyde/Development/rdk/config/reader.go:354\ngo.viam.com/rdk/config.readFromCloud\n\t/Users/jeremyhyde/Development/rdk/config/reader.go:185\ngo.viam.com/rdk/config.fromReader\n\t/Users/jeremyhyde/Development/rdk/config/reader.go:343\ngo.viam.com/rdk/config.FromReader\n\t/Users/jeremyhyde/Development/rdk/config/reader.go:317\ngo.viam.com/rdk/config.Read\n\t/Users/jeremyhyde/Development/rdk/config/reader.go:292\ngo.viam.com/rdk/web/server.(*robotServer).runServer\n\t/Users/jeremyhyde/Development/rdk/web/server/entrypoint.go:159\ngo.viam.com/rdk/web/server.RunServer\n\t/Users/jeremyhyde/Development/rdk/web/server/entrypoint.go:147\ngo.viam.com/utils.contextualMain\n\t/Users/jeremyhyde/go/pkg/mod/go.viam.com/utils@v0.1.36/runtime.go:72\ngo.viam.com/utils.ContextualMain\n\t/Users/jeremyhyde/go/pkg/mod/go.viam.com/utils@v0.1.36/runtime.go:29\nmain.main\n\t/Users/jeremyhyde/Development/rdk/web/cmd/server/main.go:19\nruntime.main\n\t/opt/homebrew/Cellar/go/1.20.5/libexec/src/runtime/proc.go:250\nruntime.goexit\n\t/opt/homebrew/Cellar/go/1.20.5/libexec/src/runtime/asm_arm64.s:1172"}
```
note: this is an upstream erro from rdk's attempts to find the executable path, this does not relate to the work done in the PR. 

**JIRA Ticket**
https://viam.atlassian.net/browse/RSDK-2841