### PR TITLE
Hot Fix: Implement Properties for RPLiDAR

### DIFF
--- a/rplidar.go
+++ b/rplidar.go
@@ -185,10 +185,12 @@ func (rp *Rplidar) getPointCloud(ctx context.Context) (pointcloud.PointCloud, er
 	return pc, nil
 }
 
-// Properties is a part of the Camera interface but is not implemented for the rplidar.
+// Properties returns information regarding the output of a camera, in this case that it returns PCDs.
 func (rp *Rplidar) Properties(ctx context.Context) (camera.Properties, error) {
-	var props camera.Properties
-	return props, errors.New("properties unimplemented")
+	props := camera.Properties{
+		SupportsPCD: true,
+	}
+	return props, nil
 }
 
 // Projector is a part of the Camera interface but is not implemented for the rplidar.


### PR DESCRIPTION
This PR implements the Properties function for RPLiDAR now that SLAM wants to check the properties of both cameras and movement sensors before full setup.