### PR TITLE
RSDK-5762 Add min_range parameter to RPLiDAR

### DIFF
--- a/rplidar.go
+++ b/rplidar.go
@@ -50,7 +50,7 @@ type Rplidar struct {
 	defaultNumScans         int
 	warmupNumDiscardedScans int
 
-	minRange float64
+	minRangeMM float64
 
 	logger golog.Logger
 }
@@ -58,13 +58,13 @@ type Rplidar struct {
 // Config describes how to configure the RPlidar component.
 type Config struct {
 	DevicePath string  `json:"device_path"`
-	MinRange   float64 `json:"min_range"`
+	MinRangeMM float64 `json:"min_range_mm"`
 }
 
 // Validate checks that the config attributes are valid for an RPlidar.
 func (conf *Config) Validate(path string) ([]string, error) {
 
-	if conf.MinRange < 0 {
+	if conf.MinRangeMM < 0 {
 		return nil, errors.New("min_range must be positive")
 	}
 
@@ -104,7 +104,7 @@ func newRplidar(ctx context.Context, _ resource.Dependencies, c resource.Config,
 		logger:                  logger,
 		defaultNumScans:         1,
 		warmupNumDiscardedScans: 5,
-		minRange:                svcConf.MinRange,
+		minRangeMM:              svcConf.MinRangeMM,
 	}
 
 	rp.mu.Lock()
@@ -166,7 +166,7 @@ func (rp *Rplidar) scan(ctx context.Context, numScans int) (pointcloud.PointClou
 			nodeDistance := float64(node.GetDist_mm_q2()) / 4
 
 			// Filter out points below minRange
-			if rp.minRange != 0 && nodeDistance < rp.minRange {
+			if nodeDistance < rp.minRangeMM {
 				continue
 			}
 

--- a/rplidar.go
+++ b/rplidar.go
@@ -107,6 +107,8 @@ func newRplidar(ctx context.Context, _ resource.Dependencies, c resource.Config,
 		minRangeMM:              svcConf.MinRangeMM,
 	}
 
+	fmt.Println("svcConf.MinRangeMM: ", svcConf.MinRangeMM)
+
 	rp.mu.Lock()
 	defer rp.mu.Unlock()
 	rp.started = true
@@ -167,6 +169,7 @@ func (rp *Rplidar) scan(ctx context.Context, numScans int) (pointcloud.PointClou
 
 			// Filter out points below minRange
 			if nodeDistance < rp.minRangeMM {
+				fmt.Println("SKIPPING POINT")
 				continue
 			}
 

--- a/rplidar.go
+++ b/rplidar.go
@@ -107,8 +107,6 @@ func newRplidar(ctx context.Context, _ resource.Dependencies, c resource.Config,
 		minRangeMM:              svcConf.MinRangeMM,
 	}
 
-	fmt.Println("svcConf.MinRangeMM: ", svcConf.MinRangeMM)
-
 	rp.mu.Lock()
 	defer rp.mu.Unlock()
 	rp.started = true
@@ -169,7 +167,6 @@ func (rp *Rplidar) scan(ctx context.Context, numScans int) (pointcloud.PointClou
 
 			// Filter out points below minRange
 			if nodeDistance < rp.minRangeMM {
-				fmt.Println("SKIPPING POINT")
 				continue
 			}
 


### PR DESCRIPTION
This PR adds a minimum range attribute to RPLiDAR. This optional parameter allows a user to define and filter out points below a certain threshold. This is useful if there are structures on your robot that you wish to remove from the resultant pointcloud.

Tested:
min_range not included
```
{
  "device_path": "/dev/ttyUSB0"
}
```
Result: MinRangeMM = 0, No points skipped (min point is at 157 mm distance)
<img width="594" alt="image" src="https://github.com/viamrobotics/rplidar/assets/34897732/ef729062-5b1e-4bd7-9814-15d49ee86a7d">


min_range_mm: 100
```
{
  "device_path": "/dev/ttyUSB0",
  "min_range_mm": 100
}
```
Result: MinRangeMM = 100, No points skipped (min point is at 157 mm distance)

<img width="527" alt="image" src="https://github.com/viamrobotics/rplidar/assets/34897732/a8f0d5ba-9fce-4a39-b785-0945271fb6ee">


min_range: 200
```
{
  "device_path": "/dev/ttyUSB0",
  "min_range_mm": 200
}
```
Result: MinRangeMM = 200, Skipping points

<img width="558" alt="Screenshot 2023-11-13 at 3 04 05 PM" src="https://github.com/viamrobotics/rplidar/assets/34897732/3d9da93d-aed7-4bdb-9de0-7eb57348dc4d">



**JIRA Ticket:** https://viam.atlassian.net/browse/RSDK-5726