### PR TITLE
RSDK-5079 Cache PointCloud Data for RPLiDAR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,10 @@ swig: sdk
 build-module: swig
 	mkdir -p bin && CGO_LDFLAGS=${CGO_LDFLAGS} go build $(GO_BUILD_LDFLAGS) -o bin/rplidar-module module/main.go
 
+.PHONY: install
+install:
+	sudo cp bin/rplidar-module /usr/local/bin/rplidar-module
+
 .PHONY: clean
 clean: clean-sdk
 	rm -rf bin gen/gen_wrap.cxx gen/gen.go

--- a/device.go
+++ b/device.go
@@ -7,6 +7,7 @@ import (
 
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rplidar/gen"
+
 	"go.viam.com/utils/usb"
 )
 

--- a/device.go
+++ b/device.go
@@ -61,7 +61,7 @@ func getRplidarDevice(devicePath string) (*rplidarDevice, error) {
 			continue
 		}
 
-		if result := possibleDriver.GetDeviceInfo(devInfo, defaultTimeoutMs); Result(result) != ResultOk {
+		if result := possibleDriver.GetDeviceInfo(devInfo, defaultDeviceTimeoutMs); Result(result) != ResultOk {
 			r := Result(result)
 			if r == ResultOpTimeout {
 				continue
@@ -93,7 +93,7 @@ func getRplidarDevice(devicePath string) (*rplidarDevice, error) {
 	healthInfo := gen.NewRplidar_response_device_health_t()
 	defer gen.DeleteRplidar_response_device_health_t(healthInfo)
 
-	if result := driver.GetHealth(healthInfo, defaultTimeoutMs); Result(result) != ResultOk {
+	if result := driver.GetHealth(healthInfo, defaultDeviceTimeoutMs); Result(result) != ResultOk {
 		gen.RPlidarDriverDisposeDriver(driver)
 		driver = nil
 		return nil, fmt.Errorf("failed to get health: %w", Result(result).Failed())

--- a/device.go
+++ b/device.go
@@ -111,7 +111,6 @@ func getRplidarDevice(devicePath string) (*rplidarDevice, error) {
 		serialNumber:     serialNumStr,
 		firmwareVersion:  firmwareVer,
 		hardwareRevision: hardwareRev,
-		mutex:            sync.Mutex{},
 	}
 
 	return rplidarDevice, nil

--- a/rplidar.go
+++ b/rplidar.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// The max time in milliseconds it should take for the rplidar to get scan data.
-	defaultTimeoutMs = uint(1000)
+	defaultDeviceTimeoutMs = uint(1000)
 	// The number of full 360 scans to complete before returning a point cloud.
 	defaultNumScans = 1
 	// The number of scans to discard at startup to ensure valid data is returned to the user.
@@ -182,7 +182,7 @@ func (rp *rplidar) scan(ctx context.Context, numScans int) (pointcloud.PointClou
 	var dropCount int
 	nodeCount := int64(defaultNodeSize)
 	for i := 0; i < numScans; i++ {
-		result := rp.device.driver.GrabScanDataHq(rp.nodes, &nodeCount, defaultTimeoutMs)
+		result := rp.device.driver.GrabScanDataHq(rp.nodes, &nodeCount, defaultDeviceTimeoutMs)
 		if Result(result) != ResultOk {
 			return nil, fmt.Errorf("bad scan: %w", Result(result).Failed())
 		}

--- a/rplidar.go
+++ b/rplidar.go
@@ -43,8 +43,8 @@ var (
 	rplidarModelByteMap = map[byte]string{24: "A1", 49: "A3", 97: "S1"}
 )
 
-// dataCache
-type pointCloudCache struct {
+// dataCache stores pointcloud data returned from the RPLiDAR for later access. This data is under mutex protection.
+type dataCache struct {
 	mutex      sync.RWMutex
 	pointCloud pointcloud.PointCloud
 }
@@ -60,7 +60,7 @@ type rplidar struct {
 
 	cancelFunc             func()
 	cacheBackgroundWorkers sync.WaitGroup
-	cache                  *pointCloudCache
+	cache                  *dataCache
 
 	logger logging.Logger
 }
@@ -107,7 +107,7 @@ func newRplidar(ctx context.Context, _ resource.Dependencies, c resource.Config,
 
 	logger.Info("found and connected to an " + rplidarModelByteMap[rplidarDevice.model] + " rplidar")
 
-	cachedPointCloud := &pointCloudCache{
+	cachedPointCloud := &dataCache{
 		mutex: sync.RWMutex{},
 	}
 

--- a/rplidar.go
+++ b/rplidar.go
@@ -107,16 +107,12 @@ func newRplidar(ctx context.Context, _ resource.Dependencies, c resource.Config,
 
 	logger.Info("found and connected to an " + rplidarModelByteMap[rplidarDevice.model] + " rplidar")
 
-	cachedPointCloud := &dataCache{
-		mutex: sync.RWMutex{},
-	}
-
 	rp := &rplidar{
 		Named:      c.ResourceName().AsNamed(),
 		device:     rplidarDevice,
 		minRangeMM: svcConf.MinRangeMM,
 
-		cache:                  cachedPointCloud,
+		cache:                  &dataCache{},
 		cacheBackgroundWorkers: sync.WaitGroup{},
 
 		logger: logger,
@@ -143,7 +139,7 @@ func newRplidar(ctx context.Context, _ resource.Dependencies, c resource.Config,
 // setupRPLiDAR starts the motor, if necessary, warms up the device, and ensures data returned to the
 // user is valid.
 func (rp *rplidar) setupRPLidar(ctx context.Context) error {
-	// Note: S1 rplidars do not need to start the motor before scanning can begin
+	// Note: S1 RPLiDARs do not need to start the motor before scanning can begin
 	if rplidarModelByteMap[rp.device.model] != "S1" {
 		rp.logger.Debug("starting motor")
 		rp.device.driver.StartMotor()

--- a/rplidar.go
+++ b/rplidar.go
@@ -187,7 +187,7 @@ func (rp *Rplidar) scan(ctx context.Context, numScans int) (pointcloud.PointClou
 	var dropCount int
 	nodeCount := int64(defaultNodeSize)
 	for i := 0; i < numScans; i++ {
-		result := rp.device.driver.GrabScanDataHq(rp.nodes, &nodeCount, defaultTimeout)
+		result := rp.device.driver.GrabScanDataHq(rp.nodes, &nodeCount, defaultTimeoutMs)
 		if Result(result) != ResultOk {
 			return nil, fmt.Errorf("bad scan: %w", Result(result).Failed())
 		}

--- a/rplidar.go
+++ b/rplidar.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	// The max time in milliseconds it should take for the rplidar to get scan data.
+	// The max time in milliseconds it should take for the RPlidar to get scan data.
 	defaultDeviceTimeoutMs = uint(1000)
 	// The number of full 360 scans to complete before returning a point cloud.
 	defaultNumScans = 1
@@ -37,13 +37,13 @@ const (
 )
 
 var (
-	// Model is the model of the rplidar
+	// Model is the model of the RPLiDAR
 	Model = resource.NewModel("viam", "lidar", "rplidar")
 	// rplidarModelByteMap maps the byte model representation to a string representation
 	rplidarModelByteMap = map[byte]string{24: "A1", 49: "A3", 97: "S1"}
 )
 
-// rplidar cotnains the connection, filters and data cached used to interface with an rplidar device.
+// rplidar contains the connection, filters and data cached used to interface with an RPLiDAR device.
 type rplidar struct {
 	resource.Named
 	resource.AlwaysRebuild
@@ -60,13 +60,13 @@ type rplidar struct {
 	logger                 logging.Logger
 }
 
-// Config describes how to configure the RPlidar component.
+// Config describes how to configure the RPLiDAR component.
 type Config struct {
 	DevicePath string  `json:"device_path"`
 	MinRangeMM float64 `json:"min_range_mm"`
 }
 
-// Validate checks that the config attributes are valid for an RPlidar.
+// Validate checks that the config attributes are valid for an RPLiDAR.
 func (conf *Config) Validate(path string) ([]string, error) {
 
 	if conf.MinRangeMM < 0 {
@@ -131,8 +131,8 @@ func newRplidar(ctx context.Context, _ resource.Dependencies, c resource.Config,
 	return rp, nil
 }
 
-// setupRPLiDAR starts the motor, if necessary, and warms up the device, discard several scans to
-// ensure data returned to the user is valid.
+// setupRPLiDAR starts the motor, if necessary, and warms up the device, discard several scans in the
+// process to ensure data returned to the user is valid.
 func (rp *rplidar) setupRPLidar(ctx context.Context) error {
 	// Note: S1 rplidars do not need to start the motor before scanning can begin
 	if rplidarModelByteMap[rp.device.model] != "S1" {
@@ -152,7 +152,7 @@ func (rp *rplidar) setupRPLidar(ctx context.Context) error {
 	return nil
 }
 
-// cachePointCloudLoop is a background process that repeatedly gets point cloud data from the rplidar
+// cachePointCloudLoop is a background process that repeatedly gets point cloud data from the RPLiDAR
 // and caches it for later access.
 func (rp *rplidar) cachePointCloudLoop(ctx context.Context) {
 	for {
@@ -172,7 +172,7 @@ func (rp *rplidar) cachePointCloudLoop(ctx context.Context) {
 	}
 }
 
-// scan uses the serial connection to the rplidar to get data and create a pointcloud from it
+// scan uses the serial connection to the RPLiDAR to get data and create a pointcloud from it
 func (rp *rplidar) scan(ctx context.Context, numScans int) (pointcloud.PointCloud, error) {
 	rp.device.mutex.Lock()
 	defer rp.device.mutex.Unlock()
@@ -227,12 +227,12 @@ func (rp *rplidar) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, e
 	return rp.cachedPointCloud, nil
 }
 
-// Images is a part of the camera interface but is not implemented for the rplidar.
+// Images is a part of the camera interface but is not implemented for the RPLiDAR.
 func (rp *rplidar) Images(ctx context.Context) ([]camera.NamedImage, resource.ResponseMetadata, error) {
 	return nil, resource.ResponseMetadata{}, errors.New("images unimplemented")
 }
 
-// Properties returns information regarding the output of a camera, in this case that it returns PCDs.
+// Properties returns information regarding the output of the RPLiDAR, in this case that it returns PCDs.
 func (rp *rplidar) Properties(ctx context.Context) (camera.Properties, error) {
 	props := camera.Properties{
 		SupportsPCD: true,
@@ -240,17 +240,17 @@ func (rp *rplidar) Properties(ctx context.Context) (camera.Properties, error) {
 	return props, nil
 }
 
-// Projector is a part of the Camera interface but is not implemented for the rplidar.
+// Projector is a part of the Camera interface but is not implemented for the RPLiDAR.
 func (rp *rplidar) Projector(ctx context.Context) (transform.Projector, error) {
 	return nil, errors.New("projector unimplemented")
 }
 
-// Stream is a part of the Camera interface but is not implemented for the rplidar.
+// Stream is a part of the Camera interface but is not implemented for the RPLiDAR.
 func (rp *rplidar) Stream(ctx context.Context, errHandlers ...gostream.ErrorHandler) (gostream.VideoStream, error) {
 	return nil, errors.New("stream unimplemented")
 }
 
-// Close stops the rplidar and disposes of the driver.
+// Close stops the RPLiDAR and disposes of the driver.
 func (rp *rplidar) Close(ctx context.Context) error {
 
 	// Close background process
@@ -272,7 +272,7 @@ func (rp *rplidar) Close(ctx context.Context) error {
 		}
 		rp.device.driver.Stop()
 		// Stop the motor
-		// Note: S1 rplidars do not require the motor to be stopped during closeout
+		// Note: S1 RPLiDAR do not require the motor to be stopped during closeout
 		if rplidarModelByteMap[rp.device.model] != "S1" {
 			rp.logger.Debug("stopping motor")
 			rp.device.driver.StopMotor()

--- a/rplidar.go
+++ b/rplidar.go
@@ -9,8 +9,6 @@ import (
 
 	"go.viam.com/rplidar/gen"
 
-	"go.viam.com/utils/usb"
-
 	goutils "go.viam.com/utils"
 
 	"github.com/golang/geo/r3"
@@ -309,27 +307,4 @@ func pointFrom(yaw, pitch, distance float64, reflectivity uint8) (r3.Vector, poi
 	d.SetIntensity(uint16(reflectivity) * 255)
 
 	return pos, d
-}
-
-func searchForDevicePath(logger logging.Logger) (string, error) {
-	var usbInfo = &usb.Identifier{
-		Vendor:  0x10c4,
-		Product: 0xea60,
-	}
-
-	usbDevices := usb.Search(
-		usb.SearchFilter{},
-		func(vendorID, productID int) bool {
-			return vendorID == usbInfo.Vendor && productID == usbInfo.Product
-		})
-
-	if len(usbDevices) == 0 {
-		return "", errors.New("no usb devices found")
-	}
-
-	logger.Debugf("detected %d lidar devices", len(usbDevices))
-	for _, comp := range usbDevices {
-		logger.Debug(comp)
-	}
-	return usbDevices[0].Path, nil
 }

--- a/rplidar.go
+++ b/rplidar.go
@@ -43,7 +43,7 @@ var (
 	rplidarModelByteMap = map[byte]string{24: "A1", 49: "A3", 97: "S1"}
 )
 
-// rplidar controls an Rplidar device.
+// rplidar cotnains the connection, filters and data cached used to interface with an rplidar device.
 type rplidar struct {
 	resource.Named
 	resource.AlwaysRebuild

--- a/rplidar.go
+++ b/rplidar.go
@@ -131,8 +131,8 @@ func newRplidar(ctx context.Context, _ resource.Dependencies, c resource.Config,
 	return rp, nil
 }
 
-// setupRPLiDAR starts the motor, if necessary, and warms up the device, discard several scans in the
-// process to ensure data returned to the user is valid.
+// setupRPLiDAR starts the motor, in necessary, warms up the device, and ensures data returned to the
+// user is valid.
 func (rp *rplidar) setupRPLidar(ctx context.Context) error {
 	// Note: S1 rplidars do not need to start the motor before scanning can begin
 	if rplidarModelByteMap[rp.device.model] != "S1" {

--- a/rplidar.go
+++ b/rplidar.go
@@ -34,25 +34,28 @@ var (
 	Model = resource.NewModel("viam", "lidar", "rplidar")
 	// rplidarModelByteMap maps the byte model representation to a string representation
 	rplidarModelByteMap = map[byte]string{24: "A1", 49: "A3", 97: "S1"}
+
+	defaultNumScans         = 1
+	warmupNumDiscardedScans = 5
 )
 
 // Rplidar controls an Rplidar device.
 type Rplidar struct {
 	resource.Named
 	resource.AlwaysRebuild
-	mu                      sync.Mutex
-	close                   bool
-	device                  rplidarDevice
-	nodes                   gen.Rplidar_response_measurement_node_hq_t
-	nodeSize                int
-	started                 bool
-	scannedOnce             bool
-	defaultNumScans         int
-	warmupNumDiscardedScans int
 
-	minRangeMM float64
+	deviceMutex *sync.Mutex
+	device      rplidarDevice
+	nodes       gen.Rplidar_response_measurement_node_hq_t
+	nodeSize    int
+	minRangeMM  float64
 
-	logger logging.Logger
+	cancelFunc       func()
+	cacheMutex       *sync.RWMutex
+	cachedPointCloud pointcloud.PointCloud
+
+	cacheBackgroundWorkers sync.WaitGroup
+	logger                 logging.Logger
 }
 
 // Config describes how to configure the RPlidar component.
@@ -98,56 +101,85 @@ func newRplidar(ctx context.Context, _ resource.Dependencies, c resource.Config,
 	logger.Info("found and connected to an " + rplidarModelByteMap[rplidarDevice.model] + " rplidar")
 
 	rp := &Rplidar{
-		Named:                   c.ResourceName().AsNamed(),
-		device:                  rplidarDevice,
-		nodeSize:                8192,
-		logger:                  logger,
-		defaultNumScans:         1,
-		warmupNumDiscardedScans: 5,
-		minRangeMM:              svcConf.MinRangeMM,
+		Named:      c.ResourceName().AsNamed(),
+		device:     rplidarDevice,
+		nodeSize:   8192,
+		minRangeMM: svcConf.MinRangeMM,
+
+		deviceMutex:            &sync.Mutex{},
+		cacheMutex:             &sync.RWMutex{},
+		cacheBackgroundWorkers: sync.WaitGroup{},
+
+		logger: logger,
 	}
 
-	rp.mu.Lock()
-	defer rp.mu.Unlock()
-	rp.started = true
-
-	// S1 rplidars do not require the motor to be started before scanning can begin
-	if rplidarModelByteMap[rp.device.model] != "S1" {
-		rp.logger.Debug("starting motor")
-		rp.device.driver.StartMotor()
+	// Setup RPLiDAR
+	if err := rp.setupRPLidar(ctx); err != nil {
+		return nil, errors.Wrap(err, "there was a problem setting up the rplidar")
 	}
-	rp.device.driver.StartScan(false, true)
-	rp.nodes = gen.New_measurementNodeHqArray(rp.nodeSize)
+
+	cancelCtx, cancelFunc := context.WithCancel(ctx)
+	rp.cancelFunc = cancelFunc
+
+	// Start background caching process
+	rp.cacheBackgroundWorkers.Add(1)
+	go func() {
+		defer rp.cacheBackgroundWorkers.Done()
+		rp.cachePointCloudLoop(cancelCtx)
+	}()
 
 	return rp, nil
 }
 
-// NextPointCloud performs a scan on the rplidar and performs some filtering to clean up the data.
-func (rp *Rplidar) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
-	rp.mu.Lock()
-	defer rp.mu.Unlock()
-
-	if rp.close {
-		return nil, errors.New("resource (rplidar) is closed")
+// setupRPLiDAR starts the motor, in necessary, and warms up the device, discard several scans to
+// ensure data returned to the user is valid.
+func (rp *Rplidar) setupRPLidar(ctx context.Context) error {
+	// Start the motor
+	// Note: S1 rplidars do not need to start the motor before scanning can begin
+	if rplidarModelByteMap[rp.device.model] != "S1" {
+		rp.logger.Debug("starting motor")
+		rp.device.driver.StartMotor()
 	}
 
-	if !rp.started {
-		return nil, errors.New("resource (rplidar) failed to initialize properly")
+	// Setup rplidar scan and scan once as per warmup procedure
+	rp.device.driver.StartScan(false, true)
+	rp.nodes = gen.New_measurementNodeHqArray(rp.nodeSize)
+
+	goutils.SelectContextOrWait(ctx, time.Duration(warmupNumDiscardedScans)*time.Second)
+	if _, err := rp.scan(ctx, warmupNumDiscardedScans); err != nil {
+		return err
 	}
 
-	pc, err := rp.getPointCloud(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return pc, nil
+	return nil
 }
 
-// Images is a part of the camera interface but is not implemented for the rplidar.
-func (rp *Rplidar) Images(ctx context.Context) ([]camera.NamedImage, resource.ResponseMetadata, error) {
-	return nil, resource.ResponseMetadata{}, errors.New("images unimplemented")
+// cachePointCloudLoop is a background process that repeatedly gets point cloud data from the rplidar
+// and caches it for later access. This will reduce delays in returning data and prevent overcrowding
+// of the rplidar's serial line.
+func (rp *Rplidar) cachePointCloudLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			pc, err := rp.scan(ctx, defaultNumScans)
+			if err != nil {
+				rp.logger.Debugf("issue getting pointcloud to cache: %v", err)
+			}
+
+			rp.cacheMutex.Lock()
+			rp.cachedPointCloud = pc
+			rp.cacheMutex.Lock()
+		}
+	}
 }
 
+// scan uses the serial connection to the rplidar to get data and creates a pointcloud from the
+// returned distances and angles
 func (rp *Rplidar) scan(ctx context.Context, numScans int) (pointcloud.PointCloud, error) {
+	rp.deviceMutex.Lock()
+	defer rp.deviceMutex.Unlock()
+
 	pc := pointcloud.New()
 	nodeCount := int64(rp.nodeSize)
 
@@ -187,21 +219,21 @@ func (rp *Rplidar) scan(ctx context.Context, numScans int) (pointcloud.PointClou
 	return pc, nil
 }
 
-func (rp *Rplidar) getPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
-	// wait and then discard scans for warmup
-	if !rp.scannedOnce {
-		rp.scannedOnce = true
-		goutils.SelectContextOrWait(ctx, time.Duration(rp.warmupNumDiscardedScans)*time.Second)
-		if _, err := rp.scan(ctx, rp.warmupNumDiscardedScans); err != nil {
-			return nil, err
-		}
-	}
+// NextPointCloud returns the current cached point cloud. If a user requests point cloud data faster than what
+// the rplidar can manage, the same point cloud as before will be returned.
+func (rp *Rplidar) NextPointCloud(ctx context.Context) (pointcloud.PointCloud, error) {
+	rp.cacheMutex.RLock()
+	defer rp.cacheMutex.RUnlock()
 
-	pc, err := rp.scan(ctx, rp.defaultNumScans)
-	if err != nil {
-		return nil, err
+	if rp.cachedPointCloud == nil {
+		return nil, errors.New("pointcloud has not been saved yet")
 	}
-	return pc, nil
+	return rp.cachedPointCloud, nil
+}
+
+// Images is a part of the camera interface but is not implemented for the rplidar.
+func (rp *Rplidar) Images(ctx context.Context) ([]camera.NamedImage, resource.ResponseMetadata, error) {
+	return nil, resource.ResponseMetadata{}, errors.New("images unimplemented")
 }
 
 // Properties returns information regarding the output of a camera, in this case that it returns PCDs.
@@ -224,9 +256,17 @@ func (rp *Rplidar) Stream(ctx context.Context, errHandlers ...gostream.ErrorHand
 
 // Close stops the rplidar and disposes of the driver.
 func (rp *Rplidar) Close(ctx context.Context) error {
-	rp.mu.Lock()
-	defer rp.mu.Unlock()
-	rp.close = true
+
+	// Close background process
+	rp.cancelFunc()
+	rp.cacheBackgroundWorkers.Done()
+
+	rp.cacheMutex.Lock()
+	defer rp.cacheMutex.Unlock()
+
+	// Close driver related resources
+	rp.deviceMutex.Lock()
+	defer rp.deviceMutex.Unlock()
 
 	if rp.device.driver != nil {
 		if rp.nodes != nil {
@@ -236,16 +276,17 @@ func (rp *Rplidar) Close(ctx context.Context) error {
 			}()
 		}
 		rp.device.driver.Stop()
-		// S1 rplidars do not require the motor to be stopped during closeout
+		// Stop the motor
+		// Note: S1 rplidars do not require the motor to be stopped during closeout
 		if rplidarModelByteMap[rp.device.model] != "S1" {
 			rp.logger.Debug("stopping motor")
 			rp.device.driver.StopMotor()
 		}
-		rp.started = false
 
 		gen.RPlidarDriverDisposeDriver(rp.device.driver)
 		rp.device.driver = nil
 	}
+
 	return nil
 }
 

--- a/rplidar.go
+++ b/rplidar.go
@@ -131,7 +131,7 @@ func newRplidar(ctx context.Context, _ resource.Dependencies, c resource.Config,
 	return rp, nil
 }
 
-// setupRPLiDAR starts the motor, in necessary, warms up the device, and ensures data returned to the
+// setupRPLiDAR starts the motor, if necessary, warms up the device, and ensures data returned to the
 // user is valid.
 func (rp *rplidar) setupRPLidar(ctx context.Context) error {
 	// Note: S1 rplidars do not need to start the motor before scanning can begin


### PR DESCRIPTION
This PR introduces a background process that will continuously ask for and cache the pointcloud from the rplidar. NextPointCloud, instead of calling the device directly, will return this cached pointcloud. This allows for faster access/return of data and will allow multiple services (ex. SLAM and data management or navigation and data management) to access pointcloud data from the rplidar rapidly.

Note: If a service pings the rplidar too frequently, the same pointcloud may be returned multiple times.

Tested locally on laptop

**JIRA Ticket:** https://viam.atlassian.net/browse/RSDK-5079