### PR TITLE
RSDK-5843 Checkout Code during module deploy

### DIFF
--- a/.github/workflows/deploy_module.yml
+++ b/.github/workflows/deploy_module.yml
@@ -66,6 +66,7 @@ jobs:
       matrix:
         platform: [amd64, arm64]
     steps:
+    - uses: actions/checkout@v3
     - uses: actions/download-artifact@v3
       with:
         name: appimage-${{ matrix.platform }}


### PR DESCRIPTION
This PR adds code checkout to module deploy to allow deploy action to see the meta.json