### PR TITLE
RSDK-2839 Create local lock file for RPLiDAR to prevent multi-sessions using same serial_path

### DIFF
--- a/device.go
+++ b/device.go
@@ -83,11 +83,7 @@ func getRplidarDevice(devicePath string) (*rplidarDevice, error) {
 	serialNum := devInfo.GetSerialnum()
 	var serialNumStr string
 	for pos := 0; pos < 16; pos++ {
-<<<<<<< HEAD
 		serialNumStr += fmt.Sprintf("%02X", gen.ByteArray_getitem(serialNum, rputils.CastInt(pos)))
-=======
-		serialNumStr += fmt.Sprintf("%02X", gen.ByteArray_getitem(serialNum, pos))
->>>>>>> c4a19d1 (remove int64 fix for mac)
 	}
 
 	firmwareVer := fmt.Sprintf("%d.%02d",

--- a/device.go
+++ b/device.go
@@ -83,7 +83,11 @@ func getRplidarDevice(devicePath string) (*rplidarDevice, error) {
 	serialNum := devInfo.GetSerialnum()
 	var serialNumStr string
 	for pos := 0; pos < 16; pos++ {
+<<<<<<< HEAD
 		serialNumStr += fmt.Sprintf("%02X", gen.ByteArray_getitem(serialNum, rputils.CastInt(pos)))
+=======
+		serialNumStr += fmt.Sprintf("%02X", gen.ByteArray_getitem(serialNum, pos))
+>>>>>>> c4a19d1 (remove int64 fix for mac)
 	}
 
 	firmwareVer := fmt.Sprintf("%d.%02d",

--- a/go.mod
+++ b/go.mod
@@ -171,6 +171,7 @@ require (
 	github.com/miekg/dns v1.1.55 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -834,6 +834,7 @@ github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HK
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
 github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=

--- a/rplidar.go
+++ b/rplidar.go
@@ -308,7 +308,6 @@ func (rp *rplidar) Close(ctx context.Context) error {
 		rp.device.driver = nil
 	}
 
-	fmt.Println("closing out lock file for current process: ", rp.lockFilePath)
 	if err := os.Remove(rp.lockFilePath); err != nil {
 		return err
 	}
@@ -343,18 +342,14 @@ func checkLockFiles(devicePath string) (string, error) {
 	// Get rplidar related processes
 	rplidarProcesses := getRplidarProcesses()
 	currentProcess := rplidarProcesses[len(rplidarProcesses)-1]
-	fmt.Println("current process PID: ", currentProcess)
 	oldProcesses := rplidarProcesses[:len(rplidarProcesses)-1]
-	fmt.Println("past process PID: ", oldProcesses)
 
 	// Get rplidar related lock files
-	fmt.Println("Possible lock files:")
 	files, err := os.ReadDir(rplidarModuleLockDir)
 	var rplidarLockFiles []string
 	for _, file := range files {
 		if strings.Contains(file.Name(), "rplidar") {
 			rplidarLockFiles = append(rplidarLockFiles, file.Name())
-			fmt.Println("- ", file.Name())
 		}
 	}
 
@@ -365,9 +360,7 @@ func checkLockFiles(devicePath string) (string, error) {
 		for _, oldProc := range oldProcesses {
 			if strings.Contains(lockFileName, fmt.Sprintf("pid%v", oldProc)) {
 				matchFound = true
-				fmt.Println("\n found lock file for pid: ", oldProc)
 				if strings.Contains(lockFileName, fmt.Sprintf("dv%v", devicePath[devicePathPrefixOffset:])) {
-					fmt.Println("found lock file for device path: ", devicePath[devicePathPrefixOffset:])
 					return "", errors.Errorf("another rplidar-module process(s) using the same serial_path has been found, "+
 						"possibly from an incomplete closure of a previous session. To use this serial path again, kill "+
 						"the old process by running 'sudo kill -9 <PID>' (PID(s): %v)", oldProc)
@@ -377,7 +370,6 @@ func checkLockFiles(devicePath string) (string, error) {
 		}
 		// Remove lock files for processes that are not currently ongoing
 		if !matchFound {
-			fmt.Println("removing lock file as no ongoing process is related to it: ", lockFileName)
 			if err := os.Remove(rplidarModuleLockDir + lockFileName); err != nil {
 				return "", err
 			}
@@ -386,7 +378,6 @@ func checkLockFiles(devicePath string) (string, error) {
 
 	// Create lock file for current session
 	newLockFile := rplidarModuleLockDir + fmt.Sprintf(rplidarModuleLockFileName, currentProcess, devicePath[devicePathPrefixOffset:])
-	fmt.Println("creating lock file for current process: ", newLockFile)
 	f, err := os.Create(newLockFile)
 	if err != nil {
 		return "", err

--- a/rplidar.go
+++ b/rplidar.go
@@ -361,7 +361,7 @@ func checkLockFiles(devicePath string) (string, error) {
 		}
 	}
 
-	// Look through lock fils for those relating to active processes + given device path, if a lock file refers to
+	// Look through lock files for those relating to active processes + given device path; if a lock file refers to
 	// a no longer active process, delete it
 	for _, lockFileName := range rplidarLockFiles {
 		var matchFound bool
@@ -369,7 +369,7 @@ func checkLockFiles(devicePath string) (string, error) {
 			if strings.Contains(lockFileName, fmt.Sprintf("pid%v", oldProc)) {
 				matchFound = true
 				if strings.Contains(lockFileName, fmt.Sprintf("dv%v", devicePath[devicePathPrefixOffset:])) {
-					return "", errors.Errorf("another rplidar-module process(s) using the same serial_path has been found, "+
+					return "", errors.Errorf("another rplidar-module process using the same serial_path has been found, "+
 						"possibly from an incomplete closure of a previous session. To use this serial path again, kill "+
 						"the old process by running 'sudo kill -9 <PID>' (PID(s): %v)", oldProc)
 				}

--- a/rplidar.go
+++ b/rplidar.go
@@ -308,8 +308,10 @@ func (rp *rplidar) Close(ctx context.Context) error {
 		rp.device.driver = nil
 	}
 
-	if err := os.Remove(rp.lockFilePath); err != nil {
-		return err
+	if _, err := os.Stat(rp.lockFilePath); err == nil {
+		if err := os.Remove(rp.lockFilePath); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This PR adds in a local lock file that is correlated to the serial_path and pid of previous sessions. Upon initialization, these lock files are checked and if one is found to be of an active process + using the same serial_path as the current session, it will produce an error signaling the user to kill the previous session.

During initialization, these lock files will also be removed if they are not related to currently running processes, and a new one will be generated, when closeout occurs this lock file is deleted.


Testing:
Testing was done to handle a variety of circumstances, the log lines below can be seen in the log-lines commit but have been removed for merge.

**No pass sessions:**
No lock files nor old processes are around so lock file is successfully created
```
JHMac-2:rdk (RSDK-6036_bump_rdk_for_slam_card) $ ls /tmp
TemporaryDirectory.cJO8eC	com.apple.launchd.Uj64ujDHi7	hi.txt
TemporaryDirectory.w3oQtE	com.apple.launchd.V3v4Hor5l1	node-jiti
```
```
\_ current process PID:  45546
\_ past process PID:  []
\_ Possible lock files:
\_ creating lock file for current process:  /tmp/rplidar_pid45546_dvttyUSB0.lock
```

during closeout: ...
`\_ removing lock file as no ongoing process is related to it:  rplidar_pid45546_dvttyUSB0.lock`

**when reconfiguration occurs:**
Reconfiguration senses the old lock file but doesn't find any old processes currently runnign related to it so deletes it and then recreates the lock file.
```
\_ current process PID:  45546
\_ past process PID:  45546
\_ Possible lock files:
\_ -  rplidar_pid45546_dvttyUSB0.lock
\_ removing lock file as no ongoing process is related to it:  rplidar_pid45546_dvttyUSB0.lock
\_ creating lock file for current process:  /tmp/rplidar_pid45546_dvttyUSB0.lock
```

**Pass sessions that canceled successfully:**
Lock file created by previous session was successfully created then deleted leaving no lock files to be checked (and no processes either).
```
JHMac-2:rdk (RSDK-6036_bump_rdk_for_slam_card) $ ls /tmp
TemporaryDirectory.cJO8eC	com.apple.launchd.Uj64ujDHi7	hi.txt
TemporaryDirectory.w3oQtE	com.apple.launchd.V3v4Hor5l1	node-jiti
```
```
\_ current process PID:  46146
\_ past process PID:  []
\_ Possible lock files:
\_ creating lock file for current process:  /tmp/rplidar_pid46146_dvttyUSB0.lock
```

**ongoing sessions with same device path:**
Previous session did not close properly leaving lock file in place. This lock file has the save device_path and PID so it causes an **error**.
```
JHMac-2:rdk (RSDK-6036_bump_rdk_for_slam_card) $ ls /tmp
TemporaryDirectory.cJO8eC	com.apple.launchd.Uj64ujDHi7	hi.txt				rplidar_pid46364_dvttyUSB0.lock
TemporaryDirectory.w3oQtE	com.apple.launchd.V3v4Hor5l1	node-jiti
```

```
\_ current process PID:  46444
\_ past process PID:  [46364]
\_ Possible lock files:
\_ -  rplidar_pid46364_dvttyUSB0.lock

\_  found lock file for pid:  46364
\_ found lock file for device path:  ttyUSB0
2024-01-23T15:18:39.802-0500	ERROR	robot_server.rdk:component:camera/rplidar	resource/graph_node.go:223	resource build error: rpc error: code = Unknown desc = another rplidar-module process(s) using the same serial_path has been found, possibly from an incomplete closure of a previous session. To use this serial path again, kill the old process by running 'sudo kill -9 <PID>' (PID(s): 46364)	{"resource":"rdk:component:camera/rplidar","model":"viam:lidar:rplidar"}
```

**ongoing session with different device path:**
Lock file still exists from bad closout of previous session, however this lock file doesn't have the same device_path and so is finee as the serial port should still be accessible. a similar set of lgos would appear if you were running multiple lidars connected to different ports.
```
JHMac-2:rdk (RSDK-6036_bump_rdk_for_slam_card) $ ls /tmp
TemporaryDirectory.cJO8eC	com.apple.launchd.Uj64ujDHi7	hi.txt				rplidar_pid46364_dvttyUSB0.lock
TemporaryDirectory.w3oQtE	com.apple.launchd.V3v4Hor5l1	node-jiti
```

```
\_ current process PID:  46610
\_ past process PID:  [46364]
\_ Possible lock files:
\_ -  rplidar_pid46364_dvttyUSB0.lock

\_  found lock file for pid:  46364
\_ creating lock file for current process:  /tmp/rplidar_pid46610_dvttyUSB1.lock
```

**JIRA Ticket:** https://viam.atlassian.net/browse/RSDK-2839