### PR TITLE
Replace defunct buildjet runners with GitHub-hosted runners

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -28,10 +28,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: [buildjet-8vcpu-ubuntu-2204]
+          - arch: [ubuntu-large]
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: amd64
-          - arch: [buildjet-2vcpu-ubuntu-2204-arm]
+          - arch: [github-linux-arm64-8core]
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: arm64
     runs-on: ${{ matrix.arch }}

--- a/.github/workflows/deploy_module.yml
+++ b/.github/workflows/deploy_module.yml
@@ -18,10 +18,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: [buildjet-8vcpu-ubuntu-2204]
+          - arch: [ubuntu-large]
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: amd64
-          - arch: [buildjet-2vcpu-ubuntu-2204-arm]
+          - arch: [github-linux-arm64-8core]
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: arm64
     runs-on: ${{ matrix.arch }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - arch: buildjet-8vcpu-ubuntu-2204
+          - arch: ubuntu-large
             image: ghcr.io/viamrobotics/rdk-devenv:amd64-cache
             platform: amd64
-          - arch: buildjet-8vcpu-ubuntu-2204-arm
+          - arch: github-linux-arm64-8core
             image: ghcr.io/viamrobotics/rdk-devenv:arm64-cache
             platform: arm64
     runs-on: ${{ matrix.arch }}


### PR DESCRIPTION
The buildjet runners no longer work, breaking these workflows. This maps them to GitHub-hosted runners, matching the fix already made in [viamrobotics/rust-utils#178](https://github.com/viamrobotics/rust-utils/pull/178):

- `buildjet-*-ubuntu-2204-arm` (native arm64 builds) → `github-linux-arm64-8core`
- `buildjet-*-ubuntu-2204` (x86) → `ubuntu-large`

Also drops the now-unused buildjet labels from `.github/actionlint.yml` where present. The amd64/arm64 build matrices and container images are otherwise untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)