### PR TITLE
Gate trusted PR workflows behind the 'safe to test' label

### DIFF
--- a/.github/workflows/appimage-comment.yml
+++ b/.github/workflows/appimage-comment.yml
@@ -17,9 +17,11 @@ jobs:
         with:
           run_id: ${{ github.event.workflow_run.id }}
           name: pr-variables
+          # absent when the appimage jobs skipped (no 'appimage' label)
+          if_no_artifact_found: ignore
 
       - name: Restore Environment
-        run: cat pr.env >> "${GITHUB_ENV}"
+        run: if [ -f pr.env ]; then cat pr.env >> "${GITHUB_ENV}"; fi
 
       - name: Add AppImage Links
         if: ${{ env.APPIMAGE }}

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -55,6 +55,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 2
+          # safe: gated by the 'safe to test' label (pr-labeler.yml)
+          allow-unsafe-pr-checkout: true
 
       - name: Clean and Fix Permissions
         run: |

--- a/.github/workflows/license_finder.yml
+++ b/.github/workflows/license_finder.yml
@@ -23,6 +23,8 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
+        # safe: gated by the 'safe to test' label (pr-labeler.yml)
+        allow-unsafe-pr-checkout: true
 
     - name: Run license finder
       run: |

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,13 @@
+name: PR Test Label Manager
+
+on:
+  pull_request_target:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  label:
+    uses: viam-modules/common-workflows/.github/workflows/pr-labeler.yaml@main
+    secrets:
+      APP_ID: ${{ secrets.CI_GITHUB_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.CI_GITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/pullrequest-trusted.yml
+++ b/.github/workflows/pullrequest-trusted.yml
@@ -6,7 +6,9 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  # gated by the 'safe to test' label (see pr-labeler.yml)
   pull_request_target:
+    types: [ labeled ]
 
 # To test workflow updates you need to work in a branch directly on viam-modules/rplidar
 # and tag your working branch instead of @main in any viam-modules/rplidar "uses" below.
@@ -14,16 +16,18 @@ on:
 
 jobs:
   license_finder:
+    if: github.event.label.name == 'safe to test' && contains(github.event.pull_request.labels.*.name, 'safe to test')
     uses: viam-modules/rplidar/.github/workflows/license_finder.yml@main
     
   test:
+    if: github.event.label.name == 'safe to test' && contains(github.event.pull_request.labels.*.name, 'safe to test')
     uses: viam-modules/rplidar/.github/workflows/test.yml@main
 
   # This lets people add an "appimage" tag to have appimages built for the PR
   appimage:
     needs: [test]
     if: |
-      always() && !cancelled() &&
+      always() && !cancelled() && contains(github.event.pull_request.labels.*.name, 'safe to test') &&
       !contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests') &&
       contains(github.event.pull_request.labels.*.name, 'appimage') && needs.test.result == 'success'
     uses: viam-modules/rplidar/.github/workflows/appimage.yml@main
@@ -35,7 +39,7 @@ jobs:
 
   appimage-ignore-tests:
     if: |
-       always() && !cancelled() &&
+       always() && !cancelled() && contains(github.event.pull_request.labels.*.name, 'safe to test') &&
        contains(github.event.pull_request.labels.*.name, 'appimage-ignore-tests')
     uses: viam-modules/rplidar/.github/workflows/appimage.yml@main
     with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,8 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 2
+        # safe: gated by the 'safe to test' label (pr-labeler.yml)
+        allow-unsafe-pr-checkout: true
 
     - name: Clean and Fix Permissions
       run: |


### PR DESCRIPTION
pullrequest-trusted.yml copied rdk's trusted-dispatcher shape but without the labeler or the `safe to test` conditions, so test and license-finder ran unreviewed fork code under `pull_request_target` on every push. This PR completes the rdk pattern:

- **pr-labeler.yml** (new): calls the reusable labeler from viam-modules/common-workflows#24 — strips `safe to test` on every push, re-adds it when the sender is a viamrobotics org member, using a CI GitHub App token so the `labeled` event retriggers CI.
- **pullrequest-trusted.yml**: triggers on `labeled` only; test (and license-finder where present) require the `safe to test` label event; the appimage jobs additionally require `safe to test` alongside their existing `appimage` labels, matching rdk.
- The PR-head checkouts in the reusable workflows set `allow-unsafe-pr-checkout: true` for the new actions/checkout guard ([announcement](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/)) — safe now that runs sit behind the label.

Merge order and prerequisites (admin): viam-modules/common-workflows#24 first, then install the CI GitHub App on this org (org-members read, issues/PR write) and share `CI_GITHUB_APP_ID`/`CI_GITHUB_APP_PRIVATE_KEY` as org secrets. The `safe to test` label already exists on the repo. Until the App is installed, a maintainer can apply the label by hand and CI runs as gated.

Known follow-up, deliberately out of scope here: appimage-comment.yml restores `$GITHUB_ENV` from a run artifact in a privileged `workflow_run` job. Artifact content is attacker-influenceable from jobs in the triggering run, and env injection there (e.g. `NODE_OPTIONS`) can execute code in the privileged job — it should validate the artifact instead of sourcing it wholesale, like viamrobotics/docs#5220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
